### PR TITLE
added '43' to ang.py expectance list

### DIFF
--- a/orix/io/plugins/ang.py
+++ b/orix/io/plugins/ang.py
@@ -351,11 +351,14 @@ def _get_phases_from_header(header):
         n_left = n_phases - len(phase_ids)
         phase_ids += [i for i in range(next_id, next_id + n_left)]
 
-    # If phases["point_group"] is a number, assume symmetry to be space group and convert to point group international
-    # notation
-    point_group_names = ['1', '-1', '2', 'm', '2/m', '222', 'mm2', 'mmm', '4', '-4', '4/m', '422', '4mm', '42m',
-                         '4/mmm', '3', '-3', '32', '3m', '-3m', '6', '-6', '6/m', '622', '6mm', '-6m2', '6/mmm', '23',
-                         'm-3', '432', '-43m', 'm-3m']
+    # If phases["point_group"] is a number, assume symmetry to be space group
+    #and convert to point group international notation
+    point_group_names = ['1', '-1', '2', 'm', '2/m', '222', 'mm2', 'mmm', '4',
+                         '-4', '4/m', '422', '4mm', '42m', '4/mmm', '3', '-3',
+                         '32', '3m', '-3m', '6', '-6', '6/m', '622', '6mm',
+                         '-6m2', '6/mmm', '23', '43', 'm-3', '432', '-43m',
+                         'm-3m'
+                         ]
     for i, phase in enumerate(phases["point_group"]):
         if phase.isdigit() and phase not in point_group_names:
             space_group = int(phase)


### PR DESCRIPTION
#### Description of the change


#### Progress of the PR
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Unit tests with pytest for all lines
- [ ] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> from orix import vector
>>> v = vector.Vector3d([1, 1, 1])
>>> # Your new feature...
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
