### PR TITLE
Ang.py symmetry unifier

### DIFF
--- a/test-folder/ang_loading_test.py
+++ b/test-folder/ang_loading_test.py
@@ -15,7 +15,7 @@ plt.rcParams.update({"figure.figsize": (7, 7), "font.size": 15})
 
 
 tempdir = '/Pyrepo/Hackathon/maxflow_for_matsci/Data/'
-fname = "steel_ebsd.ang"
+fname = "steel_ebsd_experimental.ang"
 
 target = os.path.join(tempdir, fname)
 


### PR DESCRIPTION
#### Description of the change
Reworked all of the symmetry cleaning for .ang headers. Now converts all known symmetries to their corresponding laue groups.
Removed _get_point_group_from_space_group and replaced with _symmetry_unifier function

#### Progress of the PR
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Unit tests with pytest for all lines
- [ ] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> from orix import vector
>>> v = vector.Vector3d([1, 1, 1])
>>> # Your new feature...
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
